### PR TITLE
Adds FragDepth and Lod EXT builtins

### DIFF
--- a/lib/builtins.js
+++ b/lib/builtins.js
@@ -43,6 +43,7 @@ module.exports = [
   , 'gl_FragCoord'
   , 'gl_FragData'
   , 'gl_FragDepth'
+  , 'gl_FragDepthEXT'
   , 'gl_FrontColor'
   , 'gl_FrontFacing'
   , 'gl_FrontLightModelProduct'
@@ -140,4 +141,10 @@ module.exports = [
   , 'texture2DProjLod'
   , 'textureCube'
   , 'textureCubeLod'
+  , 'texture2DLodEXT'
+  , 'texture2DProjLodEXT'
+  , 'textureCubeLodEXT'
+  , 'texture2DGradEXT'
+  , 'texture2DProjGradEXT'
+  , 'textureCubeGradEXT'
 ]


### PR DESCRIPTION
https://www.khronos.org/registry/gles/extensions/EXT/EXT_shader_texture_lod.txt
https://www.khronos.org/registry/gles/extensions/EXT/EXT_frag_depth.txt

ThreeJS uses both of these extensions.