### PR TITLE
Parse glsl files with windows carriage returns

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function tokenize(opt) {
 
   return function(data) {
     tokens = []
-    if (data !== null) return write(data)
+    if (data !== null) return write(data.replace ? data.replace(/\r\n/g, '\n') : data)
     return end()
   }
 
@@ -175,7 +175,7 @@ function tokenize(opt) {
   }
 
   function preprocessor() {
-    if(c === '\n' && last !== '\\') {
+    if((c === '\r' || c === '\n') && last !== '\\') {
       token(content.join(''))
       mode = NORMAL
       return i

--- a/test/fixture-windows.glsl
+++ b/test/fixture-windows.glsl
@@ -1,0 +1,1 @@
+#define PHYSICAL

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ var expected = require('./expected.json')
 
 var invalid = path.join(__dirname, 'invalid-chars.glsl')
 var fixture = path.join(__dirname, 'fixture.glsl')
+var fixtureWindows = path.join(__dirname, 'fixture-windows.glsl')
 var fixture300es = path.join(__dirname, 'fixture-300es.glsl')
 
 test('glsl-tokenizer/string', function(t) {
@@ -20,6 +21,20 @@ test('glsl-tokenizer/string', function(t) {
   // If this test fails, then you'll probably want to consider
   // bumping the major version.
   t.deepEqual(tokens, expected, 'matches exactly the expected output')
+
+  t.end()
+})
+
+test('glsl-tokenizer/string windows carriage returns', function(t) {
+  var src = fs.readFileSync(fixtureWindows, 'utf8')
+  var tokens = tokenizeString(src)
+
+  t.ok(Array.isArray(tokens), 'returns an array of tokens')
+  t.ok(tokens.length, 'length is above 0')
+
+  t.equal(tokens[0].data, '#define PHYSICAL');
+  // upstream in stackgl/headless-gl
+  t.equal(tokens[0].data.match(/^\s*\#\s*(.*)$/)[1], 'define PHYSICAL');
 
   t.end()
 })


### PR DESCRIPTION
Ran into an upstream failure in stackgl/headless-gl
when parsing preprocessor lines with windows carriage
returns (\r\n).

This adds a test case, and fixes it in two possible 
ways:
1. replace all \r with \n before parsing, or
2. on the preprocessor line, end at \r or \n.

The second fix is the smallest possible fix for the
issue I was running into. But the first fix seems like
a more general solution.